### PR TITLE
Support Haskell Stack projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Supports:
 - Cargo projects
 - Node projects
 - Unity Projects
+- Haskell Stack projects
 
 ## Roadmap
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ const SYMLINK_FOLLOW: bool = true;
 const FILE_CARGO_TOML: &str = "Cargo.toml";
 const FILE_PACKAGE_JSON: &str = "package.json";
 const FILE_ASSEMBLY_CSHARP: &str = "Assembly-CSharp.csproj";
+const FILE_STACK_HASKELL: &str = "stack.yaml";
 
 const PROJECT_CARGO_DIRS: [&str; 1] = ["target"];
 const PROJECT_NODE_DIRS: [&str; 1] = ["node_modules"];
@@ -18,12 +19,14 @@ const PROJECT_UNITY_DIRS: [&str; 7] = [
     "Build",
     "Builds",
 ];
+const PROJECT_STACK_DIRS: [&str; 1] = [".stack-work"];
 
 #[derive(Clone, Debug)]
 enum ProjectType {
     Cargo,
     Node,
     Unity,
+    HaskellStack,
 }
 
 #[derive(Clone, Debug)]
@@ -53,6 +56,7 @@ fn scan<P: AsRef<path::Path>>(path: &P) -> Vec<ProjectDir> {
                         Some(FILE_CARGO_TOML) => ProjectType::Cargo,
                         Some(FILE_PACKAGE_JSON) => ProjectType::Node,
                         Some(FILE_ASSEMBLY_CSHARP) => ProjectType::Unity,
+                        Some(FILE_STACK_HASKELL) => ProjectType::HaskellStack,
                         _ => return None,
                     },
                     path: entry
@@ -163,6 +167,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ProjectType::Cargo => ("Cargo", PROJECT_CARGO_DIRS.iter()),
                 ProjectType::Node => ("Node", PROJECT_NODE_DIRS.iter()),
                 ProjectType::Unity => ("Unity", PROJECT_UNITY_DIRS.iter()),
+                ProjectType::HaskellStack => ("Stack", PROJECT_STACK_DIRS.iter()),
             };
 
             let size = dirs.map(|p| dir_size(&path.join(p))).sum();


### PR DESCRIPTION
Simple change to recognize `stack.yaml`, and understand it as a Haskell Stack project with `.stack-work` as the single working directory.

Side note: I'd like to be able to add Haskell Cabal projects as well, but (a) they are identified by having a `.cabal` file named after the project, so it's not a constant string, and (b) Haskell Stack projects also include a .cabal file with the right name, but shouldn't be classified as Cabal projects.