### PR TITLE
kondo-lib: don't panic in `path_canonicalise`

### DIFF
--- a/kondo-lib/src/lib.rs
+++ b/kondo-lib/src/lib.rs
@@ -1,4 +1,7 @@
-use std::{error, fs, path};
+use std::{
+    error::{self, Error},
+    fs, path,
+};
 
 const SYMLINK_FOLLOW: bool = true;
 
@@ -329,13 +332,13 @@ pub fn clean(project_path: &str) -> Result<(), Box<dyn error::Error>> {
 
     Ok(())
 }
-
-pub fn path_canonicalise(base: &path::Path, tail: path::PathBuf) -> path::PathBuf {
+pub fn path_canonicalise(
+    base: &path::Path,
+    tail: path::PathBuf,
+) -> Result<path::PathBuf, Box<dyn Error>> {
     if tail.is_absolute() {
-        tail
+        Ok(tail)
     } else {
-        base.join(tail)
-            .canonicalize()
-            .expect("Unable to canonicalize!")
+        Ok(base.join(tail).canonicalize()?)
     }
 }

--- a/kondo/src/main.rs
+++ b/kondo/src/main.rs
@@ -19,13 +19,13 @@ struct Opt {
 
 fn prepare_directories(dirs: Vec<PathBuf>) -> Result<Vec<PathBuf>, Box<dyn Error>> {
     let cd = current_dir()?;
-    Ok(if dirs.is_empty() {
-        vec![cd]
-    } else {
-        dirs.into_iter()
-            .map(|d| path_canonicalise(&cd, d))
-            .collect()
-    })
+    if dirs.is_empty() {
+        return Ok(vec![cd]);
+    }
+
+    dirs.into_iter()
+        .map(|d| path_canonicalise(&cd, d))
+        .collect()
 }
 
 fn main() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
It can be common to call `kondo` on a path that does not exist, which yields quite badly-looking panic message:

```
$ kondo does-not-exist
thread 'main' panicked at 'Unable to canonicalize!: Os { code: 2, kind: NotFound, message: "No such file or directory" }', kondo-lib/src/lib.rs:320:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR still does not quite solve that, since the error message now looks like:

```
$ kondo does-not-exist
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

`kondo`'s error treatment is generally still quite lacking but I feel like this PR is a step in the right direction, specially if it could adopt the usage of the  [`fs-err`](https://crates.io/crates/fs-err) crate in the future