### PR TITLE
Multi threaded

### DIFF
--- a/kondo/src/main.rs
+++ b/kondo/src/main.rs
@@ -4,7 +4,7 @@ use std::{
     env::current_dir,
     error::Error,
     fmt,
-    io::{stdin, stdout, BufRead, Write},
+    io::{stdin, stdout, Write},
     num::ParseIntError,
     path::PathBuf,
     sync::mpsc::{Receiver, Sender, SyncSender},


### PR DESCRIPTION
Multi thread the CLI.

Creates a project discovery thread to look ahead and measure artifact directory size without being blocked on waiting for a user input.

Also moves deletion to another thread so the prompt isn't waiting for filesystem operations before responding to user input.

Should result in a more snappy user experience.

Also moves printing from buffered and with stdout locks to regular println. They were complicating the code for no real world benefit.