### PR TITLE
Do not remove bin folder in Gradle projects

### DIFF
--- a/kondo-lib/src/lib.rs
+++ b/kondo-lib/src/lib.rs
@@ -35,7 +35,7 @@ const PROJECT_UNITY_DIRS: [&str; 7] = [
 const PROJECT_STACK_DIRS: [&str; 1] = [".stack-work"];
 const PROJECT_SBT_DIRS: [&str; 2] = ["target", "project/target"];
 const PROJECT_MVN_DIRS: [&str; 1] = ["target"];
-const PROJECT_GRADLE_DIRS: [&str; 3] = ["bin", "build", ".gradle"];
+const PROJECT_GRADLE_DIRS: [&str; 2] = ["build", ".gradle"];
 const PROJECT_CMAKE_DIRS: [&str; 1] = ["build"];
 const PROJECT_UNREAL_DIRS: [&str; 5] = [
     "Binaries",


### PR DESCRIPTION
https://github.com/tbillington/kondo/pull/81 introduced support for Gradle projects, however I would advise against counting the `bin` folder as part of the "build files". AFAIK, Gradle only uses `build` folder for artifacts and `.gradle` for Gradle wrapper.
I do believe, many people build/download "external" binaries and put them in the `bin` folder. Sometimes, this is a part of automatic build process, and the removal of such binaries is "revertable". However, I also believe that some people (e.g., me, at least) do this manually, since it is being done only once. For example, in the cases when these binaries are necessary only for integration tests or for some extra functionality.

Long story short, `bin` folder is definitely should not be considered as "build files".