### PR TITLE
add shell completion generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ae8ba90b9d8b007efe66e55e48fb936272f5ca00349b5b0e89877520d35ea7"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +238,7 @@ name = "kondo"
 version = "0.7.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "kondo-lib",
 ]
 

--- a/kondo/Cargo.toml
+++ b/kondo/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 
 [dependencies.kondo-lib]
 path = "../kondo-lib"

--- a/kondo/src/main.rs
+++ b/kondo/src/main.rs
@@ -51,7 +51,7 @@ struct Opt {
     older: u64,
 
     /// Generates completions for the specified shell
-    #[arg(short = 'c', long = "completions", value_enum)]
+    #[arg(long = "completions", value_enum)]
     generator: Option<Shell>,
 
     /// If there is no input, defaults to yes

--- a/kondo/src/main.rs
+++ b/kondo/src/main.rs
@@ -8,7 +8,8 @@ use std::{
     sync::mpsc::{Receiver, Sender, SyncSender},
 };
 
-use clap::Parser;
+use clap::{Command, CommandFactory, Parser};
+use clap_complete::{generate, Generator, Shell};
 
 use kondo_lib::{
     dir_size, path_canonicalise, pretty_size, print_elapsed, scan, Project, ScanOptions,
@@ -48,6 +49,10 @@ struct Opt {
     /// Only directories with a file last modified n units of time ago will be looked at. Ex: 20d. Units are m: minutes, h: hours, d: days, w: weeks, M: months and y: years.
     #[arg(short, long, value_parser = parse_age_filter, default_value = "0d")]
     older: u64,
+
+    /// Generates completions for the specified shell
+    #[arg(short = 'c', long = "completions", value_enum)]
+    generator: Option<Shell>,
 
     /// If there is no input, defaults to yes
     #[arg(short, long)]
@@ -285,8 +290,21 @@ fn interactive_prompt(
     }
 }
 
+fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
+    generate(gen, cmd, cmd.get_name().to_string(), &mut stdout());
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     let mut opt = Opt::parse();
+
+    if let Some(generator) = opt.generator {
+        let mut cmd = Opt::command();
+        eprintln!("Generating completion file for {generator:?}...");
+        print_completions(generator, &mut cmd);
+        return Ok(());
+    } else {
+        println!("{opt:#?}");
+    }
 
     if opt.quiet > 0 && !opt.all {
         eprintln!("Quiet mode can only be used with --all.");

--- a/kondo/src/main.rs
+++ b/kondo/src/main.rs
@@ -302,8 +302,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         eprintln!("Generating completion file for {generator:?}...");
         print_completions(generator, &mut cmd);
         return Ok(());
-    } else {
-        println!("{opt:#?}");
     }
 
     if opt.quiet > 0 && !opt.all {


### PR DESCRIPTION
I heavily rely on shell completions for all CLI tools I use, it requires me to memorize less and prevents spelling mistakes.

This PR adds a way to generate shell completions.

Example of it running on my machine, using the zsh shell and using tab to see all possible completions:
https://asciinema.org/a/UJlAyLIj43c0NCyiQ6i700OhL