### PR TITLE
Add `.tox` to `PROJECT_PYTHON_DIRS`

### DIFF
--- a/kondo-lib/src/lib.rs
+++ b/kondo-lib/src/lib.rs
@@ -47,11 +47,12 @@ const PROJECT_UNREAL_DIRS: [&str; 5] = [
     "Intermediate",
 ];
 const PROJECT_JUPYTER_DIRS: [&str; 1] = [".ipynb_checkpoints"];
-const PROJECT_PYTHON_DIRS: [&str; 7] = [
+const PROJECT_PYTHON_DIRS: [&str; 8] = [
     ".mypy_cache",
     ".nox",
     ".pytest_cache",
     ".ruff_cache",
+    ".tox",
     ".venv",
     "__pycache__",
     "__pypackages__",


### PR DESCRIPTION
[tox](https://tox.wiki) is a test-automation program for Python projects that stores its virtual environments in a `.tox/` directory.