### PR TITLE
Add CLion support for CMake

### DIFF
--- a/kondo-lib/src/lib.rs
+++ b/kondo-lib/src/lib.rs
@@ -38,7 +38,7 @@ const PROJECT_STACK_DIRS: [&str; 1] = [".stack-work"];
 const PROJECT_SBT_DIRS: [&str; 2] = ["target", "project/target"];
 const PROJECT_MVN_DIRS: [&str; 1] = ["target"];
 const PROJECT_GRADLE_DIRS: [&str; 2] = ["build", ".gradle"];
-const PROJECT_CMAKE_DIRS: [&str; 1] = ["build"];
+const PROJECT_CMAKE_DIRS: [&str; 3] = ["build", "cmake-build-debug", "cmake-build-release"];
 const PROJECT_UNREAL_DIRS: [&str; 5] = [
     "Binaries",
     "Build",


### PR DESCRIPTION
CLion is a fairly popular C/C++ IDE and by default it creates separate debug/release build directories for CMake (there can be more but this is pretty standard)