### PR TITLE
chore: use `--locked` flag while executing tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,4 +45,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          args: --all --locked


### PR DESCRIPTION
```sh
$ cargo test -h | rg 'locked'

--locked                Require Cargo.lock is up to date
```

So that we can avoid #114 from happening :bear:
