### PR TITLE
added windows GUI install to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ Binaries available on the [releases page](https://github.com/tbillington/kondo/r
 
 ### Graphic User Interface
 
+**Windows**
+
+```powershell
+winget install kondo-ui
+```
+
+
 **Arch Linux**
 
 ```sh


### PR DESCRIPTION
This PR adds install instructions for kondo-ui on WIndows.

This is following the successful PR into winget itself

https://github.com/microsoft/winget-pkgs/pull/167496

closes #128 