### PR TITLE
readme: add MacPorts install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ winget install kondo
 brew install kondo
 ```
 
+**MacPorts**
+
+```sh
+sudo port install kondo
+```
+
 **Arch Linux**
 
 ```sh


### PR DESCRIPTION
Adds instructions for installing `kondo` via MacPorts

https://ports.macports.org/port/kondo/