### PR TITLE
feat: add `dry-run` option

### DIFF
--- a/kondo/src/main.rs
+++ b/kondo/src/main.rs
@@ -57,6 +57,10 @@ struct Opt {
     /// If there is no input, defaults to yes
     #[arg(short, long)]
     default: bool,
+
+    /// Only list the directories that would be cleaned, without actually cleaning them.
+    #[arg(short = 'n', long, conflicts_with = "all")]
+    dry_run: bool,
 }
 
 fn prepare_directories(dirs: Vec<PathBuf>) -> Result<Vec<PathBuf>, Box<dyn Error>> {
@@ -223,6 +227,7 @@ fn interactive_prompt(
     quiet: u8,
     mut clean_all: bool,
     default: bool,
+    dry_run: bool,
 ) {
     'project_loop: for (project, artifact_dirs, artifact_bytes, last_modified) in projects_recv {
         if quiet == 0 {
@@ -238,6 +243,8 @@ fn interactive_prompt(
 
         let clean_project = if clean_all {
             true
+        } else if dry_run {
+            false
         } else {
             loop {
                 print!(
@@ -347,6 +354,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         opt.quiet,
         opt.all,
         opt.default,
+        opt.dry_run,
     );
 
     let delete_results = match delete_handle.join() {


### PR DESCRIPTION
Fixes #127 

This will display all projects but will not clean any of them. Useful for previewing what will be cleaned, in case you are inclined to run `--all` for example.

In my case I just wanted to preview the results out of curiosity, but got surprised by how easy it was to implement. It's basically the opposite of the `--all` option.

I named the option `--dry-run`, with `-n` as its short version, which I think is pretty standard (GNU Make and Cargo also use `-n --dry-run`). But let me know if you prefer anything else.