### PR TITLE
dont remove .venv for python

### DIFF
--- a/kondo-lib/src/lib.rs
+++ b/kondo-lib/src/lib.rs
@@ -67,13 +67,12 @@ const PROJECT_UNREAL_DIRS: [&str; 5] = [
     "Intermediate",
 ];
 const PROJECT_JUPYTER_DIRS: [&str; 1] = [".ipynb_checkpoints"];
-const PROJECT_PYTHON_DIRS: [&str; 8] = [
+const PROJECT_PYTHON_DIRS: [&str; 7] = [
     ".mypy_cache",
     ".nox",
     ".pytest_cache",
     ".ruff_cache",
     ".tox",
-    ".venv",
     "__pycache__",
     "__pypackages__",
 ];


### PR DESCRIPTION
venvs are created intentionally sometimes, and can also take quite some work to setup. Based on user feedback it's not a good default to blow them away with a general purpose tool like kondo.